### PR TITLE
[FEAT]: add Password provider and create authentication hook

### DIFF
--- a/convex/auth.ts
+++ b/convex/auth.ts
@@ -1,6 +1,7 @@
 import Google from "@auth/core/providers/google";
 import { convexAuth } from "@convex-dev/auth/server";
+import { Password } from "@convex-dev/auth/providers/Password";
  
 export const { auth, signIn, signOut, store, isAuthenticated } = convexAuth({
-  providers: [Google],
+  providers: [Google, Password],
 });

--- a/src/app/(auth)/signin/page.tsx
+++ b/src/app/(auth)/signin/page.tsx
@@ -1,7 +1,149 @@
-import LoginPage from "@/components/login"
+'use client'
 
-const SignInPage = () => {
-  return <LoginPage />
+import { LogoIcon } from '@/components/logo'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import Link from 'next/link'
+import { useAuth } from '@/hooks/use-auth'
+import { Loader2 } from 'lucide-react'
+
+export default function LoginPage() {
+
+  const { signInForm, handleSignIn, isLoading } = useAuth();
+  const { register, handleSubmit, formState: { errors } } = signInForm;
+
+  return (
+    <section className="flex min-h-screen bg-zinc-50 px-4 py-16 md:py-32 dark:bg-transparent">
+      <form
+        onSubmit={handleSubmit(handleSignIn)}
+        className="bg-card m-auto h-fit w-full max-w-sm rounded-[calc(var(--radius)+.125rem)] border p-0.5 shadow-md dark:[--color-muted:var(--color-zinc-900)]">
+        <div className="p-8 pb-6">
+          <div>
+            <Link
+              href="/"
+              aria-label="go home">
+              <LogoIcon />
+            </Link>
+            <h1 className="mb-1 mt-4 text-xl font-semibold">Sign In to Linea</h1>
+            <p className="text-sm">Welcome back! Sign in to continue</p>
+          </div>
+
+          <div className="mt-6 grid grid-cols-2 gap-3">
+            <Button
+              type="button"
+              variant="outline">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="0.98em"
+                height="1em"
+                viewBox="0 0 256 262">
+                <path
+                  fill="#4285f4"
+                  d="M255.878 133.451c0-10.734-.871-18.567-2.756-26.69H130.55v48.448h71.947c-1.45 12.04-9.283 30.172-26.69 42.356l-.244 1.622l38.755 30.023l2.685.268c24.659-22.774 38.875-56.282 38.875-96.027"></path>
+                <path
+                  fill="#34a853"
+                  d="M130.55 261.1c35.248 0 64.839-11.605 86.453-31.622l-41.196-31.913c-11.024 7.688-25.82 13.055-45.257 13.055c-34.523 0-63.824-22.773-74.269-54.25l-1.531.13l-40.298 31.187l-.527 1.465C35.393 231.798 79.49 261.1 130.55 261.1"></path>
+                <path
+                  fill="#fbbc05"
+                  d="M56.281 156.37c-2.756-8.123-4.351-16.827-4.351-25.82c0-8.994 1.595-17.697 4.206-25.82l-.073-1.73L15.26 71.312l-1.335.635C5.077 89.644 0 109.517 0 130.55s5.077 40.905 13.925 58.602z"></path>
+                <path
+                  fill="#eb4335"
+                  d="M130.55 50.479c24.514 0 41.05 10.589 50.479 19.438l36.844-35.974C195.245 12.91 165.798 0 130.55 0C79.49 0 35.393 29.301 13.925 71.947l42.211 32.783c10.59-31.477 39.891-54.251 74.414-54.251"></path>
+              </svg>
+              <span>Google</span>
+            </Button>
+            <Button
+              type="button"
+              variant="outline">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="1em"
+                height="1em"
+                viewBox="0 0 256 256">
+                <path
+                  fill="#f1511b"
+                  d="M121.666 121.666H0V0h121.666z"></path>
+                <path
+                  fill="#80cc28"
+                  d="M256 121.666H134.335V0H256z"></path>
+                <path
+                  fill="#00adef"
+                  d="M121.663 256.002H0V134.336h121.663z"></path>
+                <path
+                  fill="#fbbc09"
+                  d="M256 256.002H134.335V134.336H256z"></path>
+              </svg>
+              <span>Microsoft</span>
+            </Button>
+          </div>
+
+          <hr className="my-4 border-dashed" />
+
+          <div className="space-y-6">
+            <div className="space-y-2">
+              <Label
+                htmlFor="email"
+                className="block text-sm">
+                Email
+              </Label>
+              <Input
+                type="email"
+                required
+                id="email"
+                {...register('email')}
+                className={errors.email ? 'border-destructive' : ''}
+              />
+              {errors.email && <p className="text-sm text-destructive">{errors.email.message}</p>}
+            </div>
+
+            <div className="space-y-0.5">
+              <div className="flex items-center justify-between">
+                <Label
+                  htmlFor="pwd"
+                  className="text-sm">
+                  Password
+                </Label>
+                <Button
+                  asChild
+                  variant="link"
+                  size="sm">
+                  <Link
+                    href="#"
+                    className="link intent-info variant-ghost text-sm">
+                    Forgot your Password ?
+                  </Link>
+                </Button>
+              </div>
+              <Input
+                type="password"
+                id="password"
+                {...register('password')}
+                className={errors.password ? 'border-destructive' : ''}
+              />
+              {errors.password && <p className="text-sm text-destructive">{errors.password.message}</p>}
+            </div>
+
+            {errors.root && <p className="text-sm text-destructive text-center">{errors.root.message}</p>}
+
+            <Button className="w-full" disabled={isLoading} type="submit">
+              {isLoading ? (<> <Loader2 className="mr-2 h-4 w-4 animate-spin" /> Signing in... </>) : ('Sign In')}
+            </Button>
+          </div>
+        </div>
+
+        <div className="bg-muted rounded-(--radius) border p-3">
+          <p className="text-accent-foreground text-center text-sm">
+            Don&apos;t have an account ?
+            <Button
+              asChild
+              variant="link"
+              className="px-2">
+              <Link href="/signup">Create account</Link>
+            </Button>
+          </p>
+        </div>
+      </form>
+    </section>
+  )
 }
-
-export default SignInPage

--- a/src/hooks/use-auth.ts
+++ b/src/hooks/use-auth.ts
@@ -1,0 +1,92 @@
+import { useAuthActions } from "@convex-dev/auth/react";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { z } from 'zod'
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+
+const signInSchema = z.object({
+    email: z.string().email('Invalid email address'),
+    password: z.string().min(8, 'Password must be at least 8 characters'),
+});
+
+const signUpSchema = z.object({
+    firstName: z.string().min(1, 'First name is required'),
+    lastName: z.string().min(1, 'Last name is required'),
+    email: z.string().email('Invalid email address'),
+    password: z.string().min(8, 'Password must be at least 8 characters'),
+});
+
+type signInData = z.infer<typeof signInSchema>;
+type signUpData = z.infer<typeof signUpSchema>
+
+export const useAuth = () => {
+    const { signIn, signOut } = useAuthActions();
+    const router = useRouter();
+    const [isLoading, setIsLoading] = useState(false);
+
+
+    const signInForm = useForm<signInData>({
+        resolver: zodResolver(signInSchema),
+        defaultValues: {
+            email: '',
+            password: '',
+        },
+    });
+
+    const signUpForm = useForm<signUpData>({
+        resolver: zodResolver(signUpSchema),
+        defaultValues: {
+            firstName: '',
+            lastName: '',
+            email: '',
+            password: '',
+        },
+    });
+
+    const handleSignIn = async (data: signInData) => {
+        setIsLoading(true);
+        try {
+            await signIn('password', {
+                email: data.email,
+                password: data.password,
+                flow: 'signIn',
+            });
+            router.push('/dashboard');
+        } catch (error) {
+            console.error(error);
+            signInForm.setError('password', { message: 'Invalid email or password' });
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
+    const handleSignUp = async (data: signUpData) => {
+        setIsLoading(true);
+        try {
+            await signIn('password', {
+                email: data.email,
+                password: data.password,
+                name: `${data.firstName} ${data.lastName}`,
+                flow: 'signUp',
+            });
+            router.push('/dashboard');
+        } catch (error) {
+            console.error(error);
+            signUpForm.setError('root', { message: 'Failed to create account' });
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
+    const handleSignOut = async () => {
+        try {
+            await signOut();
+            router.push('/auth/signin');
+        } catch (error) {
+            console.error(error);
+        }
+    };
+
+    return { signInForm, signUpForm, handleSignIn, handleSignUp, handleSignOut, isLoading };
+};


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Enabled email/password authentication alongside Google sign-in.
  - Upgraded the sign-in page with built-in form fields, validation, error messages, and loading states.
  - Streamlined post-auth navigation: successful sign-in/sign-up routes to the dashboard; sign-out returns to the sign-in page.

- Refactor
  - Centralized authentication flows into a reusable hook to ensure consistent sign-in, sign-up, and sign-out behavior across the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->