### PR TITLE
[FEAT]: create styleGuide query and implement addMoodboardImage mutation

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -15,6 +15,7 @@ import type {
 } from "convex/server";
 import type * as auth from "../auth.js";
 import type * as http from "../http.js";
+import type * as moodboard from "../moodboard.js";
 import type * as projects from "../projects.js";
 import type * as subscription from "../subscription.js";
 import type * as user from "../user.js";
@@ -30,6 +31,7 @@ import type * as user from "../user.js";
 declare const fullApi: ApiFromModules<{
   auth: typeof auth;
   http: typeof http;
+  moodboard: typeof moodboard;
   projects: typeof projects;
   subscription: typeof subscription;
   user: typeof user;

--- a/convex/moodboard.ts
+++ b/convex/moodboard.ts
@@ -1,0 +1,83 @@
+import { v } from "convex/values";
+import { mutation, query } from "./_generated/server";
+import { getAuthUserId } from "@convex-dev/auth/server";
+
+export const getMoodboardImages = query({
+    args: { projectId: v.id('projects') },
+    handler: async (ctx, { projectId }) => {
+        const userId = await getAuthUserId(ctx);
+        if (!userId) return []
+
+        const project = await ctx.db.get(projectId);
+        if (!project || project.userId !== userId) {
+            return []
+        }
+
+        const storageIds = project.moodboardImages || [];
+        const images = await Promise.all(
+            storageIds.map(async (storageId, index) => {
+                try {
+                    const url = await ctx.storage.getUrl(storageId);
+                    return {
+                        id: `convex-${storageId}`,
+                        storageId,
+                        url,
+                        uploaded: true,
+                        uploading: false,
+                        index,
+                    }
+                } catch (error) {
+                    return null
+                }
+            })
+        )
+        return images
+            .filter((image) => image !== null)
+            .sort((a, b) => a!.index - b!.index)
+    }
+})
+
+export const generateUploadUrl = mutation({
+    handler: async (ctx) => {
+        const userId = await getAuthUserId(ctx);
+        if (!userId) throw new Error("User not authenticated!")
+
+        return await ctx.storage.generateUploadUrl()
+    }
+})
+
+export const removeMoodboardImage = mutation({
+    args: {
+        projectId: v.id('projects'),
+        storageId: v.id('_storage'),
+    },
+    handler: async (ctx, { projectId, storageId }) => {
+        const userId = await getAuthUserId(ctx);
+        if (!userId) throw new Error("User not authenticated!")
+
+        const project = await ctx.db.get(projectId);
+        if (!project) {
+            throw new Error("Project not found")
+        }
+
+        if (project.userId !== userId) {
+            throw new Error("Access denied")
+        }
+
+        const currentImages = project.moodboardImages || [];
+        const updatedImages = currentImages.filter((id) => id !== storageId);
+
+        await ctx.db.patch(projectId, {
+            moodboardImages: updatedImages,
+            lastModified: Date.now(),
+        })
+
+        try {
+            await ctx.storage.delete(storageId);
+        } catch (error) {
+            console.error(`Failed to delete image from storage ${storageId} `, error);
+        }
+
+        return { success: true, imageCount: updatedImages.length }
+    }
+})

--- a/convex/moodboard.ts
+++ b/convex/moodboard.ts
@@ -81,3 +81,32 @@ export const removeMoodboardImage = mutation({
         return { success: true, imageCount: updatedImages.length }
     }
 })
+
+export const addMoodboardImage = mutation({
+    args: {
+        projectId: v.id('projects'),
+        storageId: v.id('_storage'),
+    },
+    handler: async (ctx, { projectId, storageId }) => {
+        const userId = await getAuthUserId(ctx);
+        if (!userId) throw new Error("User not authenticated!")
+
+        const project = await ctx.db.get(projectId)
+        if (!project) throw new Error('Project not found')
+
+        if (project.userId !== userId) throw new Error('Access denied')
+
+        const currentImages = project.moodboardImages || []
+        if (currentImages.length >= 5) {
+            throw new Error('You can only add up to 5 images')
+        }
+
+        const updatedImages = [...currentImages, storageId]
+        await ctx.db.patch(projectId, {
+            moodboardImages: updatedImages,
+            lastModified: Date.now()
+        })
+
+        return { success: true, imageCount: updatedImages.length }
+    }
+})

--- a/convex/projects.ts
+++ b/convex/projects.ts
@@ -99,3 +99,20 @@ export const getProjects = query({
         }));
     }
 })
+
+export const getStyleGuide = query({
+    args: { projectId: v.id('projects') },
+    handler: async (ctx, { projectId }) => {
+        const userId = await getAuthUserId(ctx);
+        if(!userId) throw new Error("User not authenticated!")
+
+        const project = await ctx.db.get(projectId);
+        if (!project) throw new Error("Project not found")
+
+        if (project.userId !== userId && !project.isPublic) {
+            throw new Error("Access denied")
+        }
+
+        return project.styleGuide ? JSON.parse(project.styleGuide) : null;
+    }
+})

--- a/src/app/(protected)/dashboard/[session]/(workspace)/canvas/layout.tsx
+++ b/src/app/(protected)/dashboard/[session]/(workspace)/canvas/layout.tsx
@@ -1,0 +1,11 @@
+import React from 'react'
+
+type Props = {}
+
+const layout = (props: Props) => {
+  return (
+    <div>layout</div>
+  )
+}
+
+export default layout

--- a/src/app/(protected)/dashboard/[session]/(workspace)/canvas/layout.tsx
+++ b/src/app/(protected)/dashboard/[session]/(workspace)/canvas/layout.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 
-type Props = {}
+type Props = {
+    children: React.ReactNode
+}
 
 const layout = (props: Props) => {
   return (

--- a/src/app/(protected)/dashboard/[session]/(workspace)/canvas/page.tsx
+++ b/src/app/(protected)/dashboard/[session]/(workspace)/canvas/page.tsx
@@ -1,0 +1,11 @@
+import React from 'react'
+
+type Props = {}
+
+const page = (props: Props) => {
+  return (
+    <div>page</div>
+  )
+}
+
+export default page

--- a/src/app/(protected)/dashboard/[session]/(workspace)/canvas/page.tsx
+++ b/src/app/(protected)/dashboard/[session]/(workspace)/canvas/page.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 
-type Props = {}
+type Props = {
+    children: React.ReactNode
+}
 
 const page = (props: Props) => {
   return (

--- a/src/app/(protected)/dashboard/[session]/(workspace)/style-guide/layout.tsx
+++ b/src/app/(protected)/dashboard/[session]/(workspace)/style-guide/layout.tsx
@@ -1,0 +1,64 @@
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { Hash, LayoutIcon, Type } from 'lucide-react'
+import React from 'react'
+
+type Props = {
+    children: React.ReactNode
+}
+
+const tabs = [
+    {
+        value: 'colors',
+        label: 'Colors',
+        icon: Hash
+
+    },
+    {
+        value: 'typography',
+        label: 'Typography',
+        icon: Type
+    },
+    {
+        value: 'moodboard',
+        label: 'Moodboard',
+        icon: LayoutIcon
+    },
+] as const
+
+const layout = ({ children }: Props) => {
+    return (
+        <Tabs defaultValue={'colors'} className='w-full'>
+            <div className='mt-36 container mx-auto px-4 sm:px-6 py-6 sm:py-8'>
+                <div>
+                    <div className='flex flex-col lg:flex-row gap-4 lg:gap-5 items-center justify-between'>
+                        <div>
+                            <h1 className='text-3xl lg:text-left text-center font-bold text-foreground'>
+                                Style Guide
+                            </h1>
+                            <p className='text-muted-foreground mt-2 text-center lg:text-left'>
+                                Customize your style guide to match your brand.
+                            </p>
+                        </div>
+                        <TabsList className='grid w-full sm:w-fit h-auto grid-cols-3 rounded-full backdrop-blur-xl bg-white/[0.08] border border-white/[0.12] saturate-150 p-2'>
+                            {tabs.map((tab) => {
+                                const Icon = tab.icon;
+                                return (
+                                    <TabsTrigger key={tab.value} value={tab.value} className='flex items-center gap-2 rounded-xl data-[state=active]:bg-white/[0.15] data-[state=active]:backdrop-blur-xl data-[state=active]:border data-[state=active]:border-white/[0.2] transition-all duration-200 text-xs sm:text-sm'>
+                                        <Icon className='w-4 h-4' />
+                                        <span className='hidden sm:inline'>{tab.label}</span>
+                                        <span className='sm:hidden'>{tab.value}</span>
+                                    </TabsTrigger>
+                                )
+                            })}
+                        </TabsList>
+                    </div>
+                </div>
+            </div>
+            <div className='container mx-auto px-4 sm:px-6 py-6 sm:py-8'>
+                { children }
+            </div>
+        </Tabs>
+    )
+}
+
+export default layout

--- a/src/app/(protected)/dashboard/[session]/(workspace)/style-guide/page.tsx
+++ b/src/app/(protected)/dashboard/[session]/(workspace)/style-guide/page.tsx
@@ -1,0 +1,61 @@
+import Moodboard from '@/components/moodboard'
+import { ThemeContent } from '@/components/theme'
+import StyleGuideTypography from '@/components/typography'
+import { TabsContent } from '@/components/ui/tabs'
+import { MoodboardImagesQuery, StyleGuideQuery } from '@/convex/query.config'
+import { MoodboardImage } from '@/hooks/use-styles'
+import { StyleGuide } from '@/redux/api/style-guide'
+import { Palette } from 'lucide-react'
+import React from 'react'
+
+type Props = {
+    searchParams: Promise<{ project: string }>
+}
+
+const page = async ({ searchParams }: Props) => {
+
+    const projectId = (await searchParams).project;
+    const styleGuide = await StyleGuideQuery(projectId);
+
+    const guide = styleGuide.styleGuide?._valueJSON as unknown as StyleGuide;
+
+    const colorGuide = guide?.colorSections || [];
+    const typographyGuide = guide?.typographySections || [];
+
+    const moodboards = await MoodboardImagesQuery(projectId)
+    const guideImages = moodboards.images._valueJSON as unknown as MoodboardImage[]
+
+    return (
+        <div>
+            <TabsContent value='colors' className='space-y-6'>
+                {!guideImages.length ? (
+                    <div className='space-y-8'>
+                        <div className='text-center py-20'>
+                            <div className='w-16 h-16 mx-auto mb-4 rounded-lg bg-muted flex items-center justify-center'>
+                                <Palette className='w-8 h-8 text-muted-foreground' />
+                            </div>
+                            <h3 className='text-lg font-medium text-foreground mb-2'>
+                                No colors generated
+                            </h3>
+                            <p className='text-sm text-muted-foreground max-w-md mx-auto mb-6'>
+                                Upload images to moodboard to generate colors and typography style guide.
+                            </p>
+                        </div>
+                    </div>
+                ) : (
+                    <ThemeContent colorGuide={colorGuide}/>
+                )}
+            </TabsContent>
+
+            <TabsContent value='typography'>
+                <StyleGuideTypography typographyGuide={typographyGuide} />
+            </TabsContent>
+
+            <TabsContent value='moodboard'>
+                <Moodboard guideImages={guideImages} />
+            </TabsContent>
+        </div>
+    )
+}
+
+export default page

--- a/src/components/moodboard/index.tsx
+++ b/src/components/moodboard/index.tsx
@@ -1,4 +1,4 @@
-import { MoodboardImage } from '@/hooks/use-styles'
+import { MoodboardImage, useMoodboard } from '@/hooks/use-styles'
 import React from 'react'
 
 type Props = {
@@ -6,15 +6,18 @@ type Props = {
 }
 
 const Moodboard = ({ guideImages }: Props) => {
-  return (
-    <div className='flex flex-col gap-10'>
-        <div className='relative border-2 border-dashed rounded-3xl p-12 text-center transition-all duration-200 min-h-[500px] flex items-center justify-center' />
-        <div className='absolute inset-0 opacity-5'>
-            <div className='w-full h-full bg-gradient-to-br from-primary/20 to-transparent rounded-3xl' />
-        </div>
 
-    </div>
-  )
+    const { images, dragActive, removeImage, handleDrag, handleDrop, handleFileInput, canAddMore } = useMoodboard(guideImages)
+
+    return (
+        <div className='flex flex-col gap-10'>
+            <div className='relative border-2 border-dashed rounded-3xl p-12 text-center transition-all duration-200 min-h-[500px] flex items-center justify-center' />
+            <div className='absolute inset-0 opacity-5'>
+                <div className='w-full h-full bg-gradient-to-br from-primary/20 to-transparent rounded-3xl' />
+            </div>
+
+        </div>
+    )
 }
 
 export default Moodboard

--- a/src/components/moodboard/index.tsx
+++ b/src/components/moodboard/index.tsx
@@ -1,0 +1,20 @@
+import { MoodboardImage } from '@/hooks/use-styles'
+import React from 'react'
+
+type Props = {
+    guideImages: MoodboardImage[]
+}
+
+const Moodboard = ({ guideImages }: Props) => {
+  return (
+    <div className='flex flex-col gap-10'>
+        <div className='relative border-2 border-dashed rounded-3xl p-12 text-center transition-all duration-200 min-h-[500px] flex items-center justify-center' />
+        <div className='absolute inset-0 opacity-5'>
+            <div className='w-full h-full bg-gradient-to-br from-primary/20 to-transparent rounded-3xl' />
+        </div>
+
+    </div>
+  )
+}
+
+export default Moodboard

--- a/src/components/swatch/index.tsx
+++ b/src/components/swatch/index.tsx
@@ -1,0 +1,23 @@
+import { cn } from "@/lib/utils"
+
+type ColorSwatchProps = {
+    name: string
+    value: string
+    className?: string
+}
+
+export const ColorSwatch = ({ name, value, className }: ColorSwatchProps) => {
+    return (
+        <div className={cn('flex items-center gap-3', className)}>
+            <div className="w-12 h-12 rounded-lg border border-border/20 flex-shrink-0" style={{ backgroundColor: value }} />
+            <div className="space-y-1 min-w-0 flex-1">
+                <h4 className="text-sm font-medium text-foreground">
+                    {name}
+                </h4>
+                <p className="text-xs text-muted-foreground font-mono uppercase">
+                    {value}
+                </p>
+            </div>
+        </div>
+    )
+}

--- a/src/components/theme/index.tsx
+++ b/src/components/theme/index.tsx
@@ -1,0 +1,48 @@
+import { cn } from "@/lib/utils"
+import { ColorSwatch } from "../swatch"
+
+type Props = {
+    title: string
+    swatches: Array<{
+        name: string
+        hexColor: string
+        description?: string
+    }>
+    className?: string
+}
+
+export const ColorTheme = ({ title, swatches, className }: Props) => {
+    return (
+        <div className={cn('flex flex-col gap-5', className)}>
+            <div>
+                <h3 className="text-lg font-medium text-foreground/50">{title}</h3>
+            </div>
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+                {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
+                {swatches.map((swatch: any) => (
+                    <div key={swatch.name}>
+                        <ColorSwatch name={swatch.name} value={swatch.hexColor} />
+                        {swatch.description && (
+                            <p className="text-xs text-muted-foreground mt-2">
+                                {swatch.description}
+                            </p>
+                        )}
+                    </div>
+                ))}
+            </div>
+        </div>
+    )
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const ThemeContent = ({ colorGuide }: { colorGuide: any[] }) => {
+    return (
+        <div className="flex flex-col gap-10">
+            <div className="flex flex-col gap-10">
+                {colorGuide.map((section, index) => (
+                    <ColorTheme key={index} title={section.title} swatches={section.swatches} />
+                ))}
+            </div>
+        </div>
+    )
+}

--- a/src/components/typography/index.tsx
+++ b/src/components/typography/index.tsx
@@ -1,0 +1,69 @@
+import { Type } from 'lucide-react'
+import React from 'react'
+
+type Props = {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    typographyGuide: any
+}
+
+const StyleGuideTypography = ({ typographyGuide }: Props) => {
+    return (
+        <>
+            {typographyGuide.length === 0 ? (
+                <div className='text-center py-20'>
+                    <Type className='w-16 h-16 mx-auto mb-4 text-muted-foreground' />
+                    <h3 className='text-lg font-medium text-foreground mb-2'>
+                        No typography generated
+                    </h3>
+                    <p className='text-sm text-muted-foreground mb-6'>
+                        Generate typography style guide for typography
+                    </p>
+                </div>
+            ) : (
+                <div className='flex flex-col gap-10'>
+                    {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
+                    {typographyGuide.map((section: any, index: number) => (
+                        <div key={index} className='flex flex-col gap-5'>
+                            <div>
+                                <h3 className='text-lg font-medium text-foreground/50'>
+                                    {section.title}
+                                </h3>
+                            </div>
+                            <div className='grid grid-cols-1 md:grid-cols-2 gap-6'>
+                                {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
+                                {section.styles?.map((style: any, styleIndex: number) => (
+                                    <div key={styleIndex} className='p-6 rounded-2xl backdrop-blur-xl bg-white/[0.02] border border-white/[0.08] saturate-150'>
+                                        <div className='space-y-4'>
+                                            <h4 className='text-lg font-medium text-foreground mb-1'>
+                                                {style.name}
+                                            </h4>
+                                            {style.description && (
+                                                <p className='text-xs text-muted-foreground'>
+                                                    {style.description}
+                                                </p>
+                                            )}
+                                        </div>
+                                        <div className='text-foreground' style={{ fontFamily: style.fontFamily, fontSize: style.fontSize, fontWeight: style.fontWeight, lineHeight: style.lineHeight, letterSpacing: style.letterSpacing || 'normal' }}>
+                                            The quick brown fox jumps over the lazy dog
+                                        </div>
+                                        <div className='text-xs text-muted-foreground space-y-1'>
+                                            <div>Font : {style.fontFamily}</div>
+                                            <div>Size: {style.fontSize}</div>
+                                            <div>Weight: {style.fontWeight}</div>
+                                            <div>Line Height: {style.lineHeight}</div>
+                                            {style.letterSpacing && (
+                                                <div>Letter Spacing: {style.letterSpacing}</div>
+                                            )}
+                                        </div>
+                                    </div>
+                                ))}
+                            </div>
+                        </div>
+                    ))}
+                </div>
+            )}
+        </>
+    )
+}
+
+export default StyleGuideTypography

--- a/src/convex/query.config.ts
+++ b/src/convex/query.config.ts
@@ -48,3 +48,23 @@ export const ProjectQuery = async () => {
 
     return { projects, profile }
 }
+
+export const StyleGuideQuery = async (projectId: string) => {
+    const styleGuide = await preloadQuery(
+        api.projects.getStyleGuide,
+        { projectId: projectId as Id<'projects'>},
+        { token: await convexAuthNextjsToken() }
+    )
+
+    return {styleGuide};
+}
+
+export const MoodboardImagesQuery = async (projectId: string) => {
+    const images = await preloadQuery(
+        api.moodboard.getMoodboardImages,
+        { projectId: projectId as Id<'projects'>},
+        { token: await convexAuthNextjsToken() }
+    )
+
+    return { images };
+}

--- a/src/hooks/use-styles.ts
+++ b/src/hooks/use-styles.ts
@@ -3,6 +3,8 @@ import { useSearchParams } from "next/navigation"
 import { useEffect, useState } from "react"
 import { useForm } from "react-hook-form"
 import { api } from "../../convex/_generated/api"
+import { toast } from "sonner"
+import { Id } from "../../convex/_generated/dataModel"
 
 export interface MoodboardImage {
     id: string
@@ -36,6 +38,36 @@ export const useMoodboard = (guideImages: MoodboardImage[]) => {
 
     const generateUploadUrl = useMutation(api.moodboard.generateUploadUrl)
     const removeMoodboardImage = useMutation(api.moodboard.removeMoodboardImage)
+    const addMoodboardImage = useMutation(api.moodboard.addMoodboardImage)
+
+    const uploadImage = async (file: File): Promise<{ storageId: string; url?: string }> => {
+        try {
+            const uploadUrl = await generateUploadUrl()
+            const result = await fetch(uploadUrl, {
+                method: 'POST',
+                body: file,
+                headers: {
+                    'Content-Type': file.type,
+                },
+            })
+            if (!result.ok) {
+                throw new Error(`Upload failed: ${result.statusText}`)
+            }
+
+            const { storageId } = await result.json()
+            if (projectId) {
+                await addMoodboardImage({
+                    projectId: projectId as Id<'projects'>,
+                    storageId: storageId as Id<'_storage'>
+                })
+            }
+
+            return { storageId }
+        } catch (error) {
+            console.error(error)
+            throw error
+        }
+    }
 
     useEffect(() => {
         if (guideImages && guideImages.length > 0) {
@@ -67,4 +99,143 @@ export const useMoodboard = (guideImages: MoodboardImage[]) => {
             }
         }
     }, [guideImages, setValue, getValues])
+
+    const addImage = (file: File) => {
+        if (images.length >= 5) {
+            toast.error('You can only add up to 5 images')
+            return
+        }
+
+        const newImage: MoodboardImage = {
+            id: `${Date.now()}-${Math.random()}`,
+            file,
+            preview: URL.createObjectURL(file),
+            uploaded: false,
+            uploading: false,
+            isFromServer: false
+        }
+
+        const updatedImages = [...images, newImage]
+        setValue('images', updatedImages)
+
+        toast.success('Image added successfully')
+    }
+
+    const removeImage = async (imageId: string) => {
+        const imageToRemove = images.find((image) => image.id === imageId)
+        if (!imageToRemove) return
+
+        if (imageToRemove.isFromServer && imageToRemove.storageId && projectId) {
+            try {
+                await removeMoodboardImage({
+                    projectId: projectId as Id<'projects'>,
+                    storageId: imageToRemove.storageId as Id<'_storage'>
+                })
+            } catch (error) {
+                console.error(error)
+                toast.error('Failed to remove image')
+                return
+            }
+        }
+
+        const updatedImages = images.filter((image) => {
+            if (image.id === imageId) {
+                if (!image.isFromServer && image.preview.startsWith('blob:')) {
+                    URL.revokeObjectURL(image.preview)
+                }
+                return false
+            }
+            return true
+        })
+        setValue('images', updatedImages)
+        toast.success('Image removed successfully')
+    }
+
+    const handleDrag = (e: React.DragEvent) => {
+        e.preventDefault()
+        e.stopPropagation()
+
+        if (e.type === 'dragenter' || e.type === 'dragover') {
+            setDragActive(true)
+        } else if (e.type === 'dragleave') {
+            setDragActive(false)
+        }
+    }
+
+    const handleDrop = (e: React.DragEvent) => {
+        e.preventDefault()
+        e.stopPropagation()
+
+        setDragActive(false)
+
+        const files = Array.from(e.dataTransfer.files)
+        const imageFiles = files.filter((file) => file.type.startsWith('image/'))
+
+        if (imageFiles.length === 0) {
+            toast.error('Please drag and drop images only')
+            return
+        }
+
+        imageFiles.forEach((file) => {
+            if (images.length < 5) {
+                addImage(file)
+            }
+        })
+    }
+
+    const handleFileInput = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const files = Array.from(e.target.files || [])
+        files.forEach((file) => addImage(file))
+        e.target.value = ''
+    }
+
+    useEffect(() => {
+        const uploadPendingImages = async () => {
+            const currentImages = getValues('images')
+            for (let i = 0; i < currentImages.length; i++) {
+                const image = currentImages[i]
+                if (!image.uploaded && !image.uploading && !image.error) {
+                    const updatedImages = [...currentImages]
+                    updatedImages[i] = { ...image, uploading: true }
+                    setValue('images', updatedImages)
+                    try {
+                        const { storageId } = await uploadImage(image.file!)
+                        const finalImages = getValues('images')
+                        const finalIndex = finalImages.findIndex(
+                            (img) => img.id === image.id
+                        )
+                        if (finalIndex !== -1) {
+                            finalImages[finalIndex] = {
+                                ...finalImages[finalIndex],
+                                storageId,
+                                uploaded: true,
+                                uploading: false,
+                                isFromServer: true
+                            }
+                            setValue('images', [...finalImages])
+                        }
+                    } catch (error) {
+                        console.error(error)
+                        const errorImages = getValues('images')
+                        const errorIndex = errorImages.findIndex(
+                            (img) => img.id === image.id
+                        )
+                        if (errorIndex !== -1) {
+                            errorImages[errorIndex] = {
+                                ...errorImages[errorIndex],
+                                uploading: false,
+                                error: 'Upload Failed'
+                            }
+                            setValue('images', [...errorImages])
+                        }
+                    }
+                }
+            }
+        }
+
+        if (images.length > 0) {
+            uploadPendingImages()
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [images, setValue, getValues])
 }

--- a/src/hooks/use-styles.ts
+++ b/src/hooks/use-styles.ts
@@ -1,3 +1,5 @@
+'use client'
+
 import { useMutation } from "convex/react"
 import { useSearchParams } from "next/navigation"
 import { useEffect, useState } from "react"
@@ -238,4 +240,25 @@ export const useMoodboard = (guideImages: MoodboardImage[]) => {
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [images, setValue, getValues])
+
+    useEffect(() => {
+        return () => {
+            images.forEach((image) => {
+                URL.revokeObjectURL(image.preview)
+            })
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [])
+
+    return {
+        form,
+        images,
+        dragActive,
+        addImage,
+        removeImage,
+        handleDrag,
+        handleDrop,
+        handleFileInput,
+        canAddMore: images.length < 5
+    }
 }

--- a/src/hooks/use-styles.ts
+++ b/src/hooks/use-styles.ts
@@ -1,0 +1,70 @@
+import { useMutation } from "convex/react"
+import { useSearchParams } from "next/navigation"
+import { useEffect, useState } from "react"
+import { useForm } from "react-hook-form"
+import { api } from "../../convex/_generated/api"
+
+export interface MoodboardImage {
+    id: string
+    file?: File
+    preview: string
+    storageId?: string
+    uploaded: boolean
+    uploading: boolean
+    error?: string
+    url?: string
+    isFromServer?: boolean
+}
+
+interface StylesFormData {
+    images: MoodboardImage[]
+}
+
+export const useMoodboard = (guideImages: MoodboardImage[]) => {
+    const [dragActive, setDragActive] = useState(false)
+    const searchParams = useSearchParams()
+    const projectId = searchParams.get('project')
+
+    const form = useForm<StylesFormData>({
+        defaultValues: {
+            images: [],
+        }
+    })
+
+    const { watch, setValue, getValues } = form
+    const images = watch('images')
+
+    const generateUploadUrl = useMutation(api.moodboard.generateUploadUrl)
+    const removeMoodboardImage = useMutation(api.moodboard.removeMoodboardImage)
+
+    useEffect(() => {
+        if (guideImages && guideImages.length > 0) {
+            const serverImages: MoodboardImage[] = guideImages.map((image) => ({
+                id: image.id,
+                preview: image.preview,
+                storageId: image.storageId,
+                uploaded: true,
+                uploading: false,
+                url: image.url,
+            }))
+            const currentImages = getValues('images')
+
+            if (currentImages.length === 0) {
+                setValue('images', serverImages)
+            } else {
+                const mergedImages = [...currentImages]
+                serverImages.forEach((serverImage) => {
+                    const clientIndex = mergedImages.findIndex((clientImage) => clientImage.storageId === serverImage.storageId)
+
+                    if (clientIndex !== -1) {
+                        if (mergedImages[clientIndex].preview.startsWith('blob:')) {
+                            URL.revokeObjectURL(mergedImages[clientIndex].preview)
+                        }
+                        mergedImages[clientIndex] = serverImage
+                    }
+                })
+                setValue('images', mergedImages)
+            }
+        }
+    }, [guideImages, setValue, getValues])
+}

--- a/src/redux/api/style-guide/index.ts
+++ b/src/redux/api/style-guide/index.ts
@@ -1,0 +1,47 @@
+export interface ColorSwatch {
+    name: string
+    hexColor: string
+    description?: string
+}
+
+export interface ColorSection {
+    title:
+        | 'Primary Colors'
+        | 'Secondary & Accent Colors'
+        | 'UI Component Colors'
+        | 'Utility & Form Colors'
+        | 'Status & Feedback Colors'
+    swatches: ColorSwatch[]
+}
+
+export interface TypographyStyle {
+    name: string
+    fontFamily: string
+    fontSize: string
+    fontWeight: string
+    lineHeight: string
+    letterSpacing?: string
+    description?: string
+}
+
+export interface TypographySection {
+    title: string
+    styles: TypographyStyle[]
+}
+
+export interface StyleGuide {
+    theme: string;
+    description: string;
+    colorSections: [
+        ColorSection,
+        ColorSection,
+        ColorSection,
+        ColorSection,
+        ColorSection,
+    ]
+    typographySections: [
+        TypographySection,
+        TypographySection,
+        TypographySection,
+    ]
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced a Style Guide workspace with tabs: Colors, Typography, and Moodboard.
  - Colors: View organized color themes with swatches and labels.
  - Typography: Browse style cards with live text previews and font details.
  - Moodboard: Add images via drag-and-drop or file picker, remove images, and manage up to 5 images per project with persistence.
  - Seamless data loading for style guide and moodboard content within the dashboard.
  - Added foundational canvas routes for future workspace experiences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->